### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ COPY docker/entrypoint.sh ./entrypoint.sh
 # Final operations
 RUN chmod +x ./entrypoint.sh
 ARG COMMIT_SHA
-ENV COMMIT_SHA ${COMMIT_SHA}
+ENV COMMIT_SHA=${COMMIT_SHA}
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]


### PR DESCRIPTION
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 30)